### PR TITLE
Update assistive technology attributes

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -9,9 +9,9 @@
             </div>
 
             <div class="footer__links">
-                <a href="http://meetup.com/daytondv"><img src="/images/meetup-logo.svg" /></a>
-                <a href="https://github.com/daytondv" alt="GitHub"><i class="fa fa-github"></i></a>
-                <a href="https://twitter.com/daytondv" alt="Twitter"><i class="fa fa-twitter"></i></a>
+                <a href="http://meetup.com/daytondv"><img src="/images/meetup-logo.svg" alt="Meetup logo" /></a>
+                <a href="https://github.com/daytondv" title="GitHub"><i class="fa fa-github"></i></a>
+                <a href="https://twitter.com/daytondv" title="Twitter"><i class="fa fa-twitter"></i></a>
                 <a href="http://workatais.com"><img src="/images/sponsors/ais-white.png" alt="Applied Information Sciences" /></a>
 
             </div>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -7,7 +7,7 @@
         </div>
         <div class="meetup-btn">
             <a class="button-primary" href="http://meetup.com/daytondv">
-                <img src="/images/meetup-logo.svg" />
+                <img src="/images/meetup-logo.svg" alt="" />
                 Join us!
             </a>
         </div>

--- a/src/events.html
+++ b/src/events.html
@@ -11,12 +11,12 @@ permalink: /events/
         <p>{{ event.description }}</p>
         {% if event.youtube %}
             <a class="button" href="{{ event.youtube }}">
-                <img src="/images/youtube.svg" />
+                <img src="/images/youtube.svg" alt="" />
                 YouTube
             </a>
         {% else %}
             <a class="button" href="{{ event.rsvp }}">
-                <img src="/images/meetup-logo.svg" />
+                <img src="/images/meetup-logo.svg" alt="" />
                 RSVP
             </a>
         {% endif %}

--- a/src/index.html
+++ b/src/index.html
@@ -13,12 +13,12 @@ layout: home
             <p>{{ event.description }}</p>
             {% if event.youtube %}
                 <a class="button" href="{{ event.youtube }}">
-                    <img src="/images/youtube.svg" />
+                    <img src="/images/youtube.svg" alt="" />
                     YouTube
                 </a>
             {% else %}
                 <a class="button" href="{{ event.rsvp }}">
-                    <img src="/images/meetup-logo.svg" />
+                    <img src="/images/meetup-logo.svg" alt="" />
                     RSVP
                 </a>
             {% endif %}


### PR DESCRIPTION
Added empty alt attributes for image elements that have no additional information for assistive technology, marking them as ignored.

Updated the alt attributes on the Twitter & Github links in the footer to be title attributes which are element appropriate

Related to issue: #15