### PR TITLE
Update the colour of the copyright text to be AA compliant

### DIFF
--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -84,7 +84,7 @@
 }
 
 .footer__copy {
-    color: lighten($clr-dark, 35%);
+    color: lighten($clr-dark, 45%);
     font-family: $font-heading;
     font-size: 65%;
     padding: 1.5em;


### PR DESCRIPTION
The copyright text in the footer currently has too little contrast (ratio of 3.64) to be AA compliant which requires (a ratio of 4.54). I've lightened the colour enough to achieve AA, with a new ratio of 5.13. It will need to go lighter still for AAA (a ratio of 7.03).